### PR TITLE
Remove version banner from rota generator

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,6 @@
 <body>
   <h1>Neurosurgical SHO Rota Generator</h1>
   <p>Select your weekly rota Excel file and enter the number of admissions for each day to generate team allocations, clerking duties and daily messages.</p>
-  <p style="font-size: 12px; color: #7f8c8d;">Version: 2025-10-02 02:02 - Force grey empty cells</p>
   <!-- Tab navigation -->
   <div id="tab-buttons">
     <button id="tab-generator" class="tab-btn active" type="button">Rota Generator</button>


### PR DESCRIPTION
## Summary
- remove the outdated version banner from the rota generator landing text so the page has no hardcoded release string

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df01d30c8c832893ab77407d402926