### PR TITLE
Handle formula blanks in Excel export

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,12 +201,41 @@
 
 
   <script>
+  // Treats null/undefined/blank (including formula blanks "") values as empty
+  function isEffectivelyEmpty(value) {
+    if (value === undefined || value === null) return true;
+    let strValue;
+    if (typeof value === 'string') {
+      strValue = value;
+    } else if (typeof value === 'number') {
+      return false;
+    } else if (typeof value === 'boolean') {
+      return false;
+    } else if (value && typeof value.toString === 'function') {
+      strValue = value.toString();
+    } else {
+      return false;
+    }
+
+    const cleaned = strValue.replace(/\u200b/g, '').trim();
+    if (cleaned === '') return true;
+
+    // Remove wrapping straight or smart quotes before final emptiness check
+    const withoutQuotes = cleaned.replace(/^[\"\u201C\u201D]+|[\"\u201C\u201D]+$/g, '').trim();
+    return withoutQuotes === '';
+  }
+
+  function stripWrappingQuotes(value) {
+    if (typeof value !== 'string') return value;
+    return value.replace(/^[\"\u201C\u201D]+|[\"\u201C\u201D]+$/g, '');
+  }
+
   // Utility to parse a single shift cell into structured data
   function parseShift(str) {
-    if (!str || typeof str !== 'string' || str.trim() === '' || str.trim() === '\u200b') {
+    if (isEffectivelyEmpty(str)) {
       return { available: false, start_time: null, assignment: null, on_call: false, night: false };
     }
-    const s = str.trim().toUpperCase();
+    const s = stripWrappingQuotes(str.toString().replace(/\u200b/g, '').trim()).toUpperCase();
     // Leave keywords (annual leave, study leave, zero/induction/weiss)
     // Include 'SL' for study leave
     if (/^(AL|SL|ZERO|INDUCTION|WEISS)\b/.test(s)) {
@@ -1761,10 +1790,9 @@
         
         // Robust empty check: handles undefined, null, empty string, and whitespace
         const cellValue = newSheet[cellAddress].v;
-        const hasValue = cellValue != null && String(cellValue).trim() !== '';
-        
+
         // Force grey for empty cells (override any template fills)
-        if (!hasValue) {
+        if (isEffectivelyEmpty(cellValue)) {
           newSheet[cellAddress].s.fill = {
             patternType: 'solid',
             fgColor: { rgb: colors.offDay }
@@ -1801,9 +1829,8 @@
         if (!newSheet[cellAddress].s) newSheet[cellAddress].s = {};
         // Determine if cell is empty
         const value = newSheet[cellAddress].v;
-        const hasVal = value != null && String(value).trim() !== '';
         // Grey fill for empty cells
-        if (!hasVal) {
+        if (isEffectivelyEmpty(value)) {
           newSheet[cellAddress].s.fill = {
             patternType: 'solid',
             fgColor: { rgb: colors.offDay }
@@ -1847,9 +1874,11 @@
         }
         // Robust empty check: handles undefined, null, empty string, and whitespace
         const cellValue = newSheet[cellAddress].v;
-        const hasValue = cellValue != null && String(cellValue).trim() !== '';
+        if (C === 2) {
+          continue; // Preserve firm colours in column C
+        }
         // For rows 22-24, FORCE grey if empty (override any team colors)
-        if (!hasValue) {
+        if (isEffectivelyEmpty(cellValue)) {
           newSheet[cellAddress].s.fill = {
             patternType: 'solid',
             fgColor: { rgb: colors.offDay }
@@ -1874,8 +1903,7 @@
           }
           if (!newSheet[addr].s) newSheet[addr].s = {};
           const val = newSheet[addr].v;
-          const hasVal = val != null && String(val).trim() !== '';
-          if (!hasVal) {
+          if (isEffectivelyEmpty(val)) {
             newSheet[addr].s.fill = {
               patternType: 'solid',
               fgColor: { rgb: colors.offDay }
@@ -1904,8 +1932,11 @@
         const cellAddress = XLSX.utils.encode_cell({ r: rIdx, c: colIndex });
         // Get original shift text from rotaData
         const originalVal = row[dayName];
-        const originalText = originalVal != null ? originalVal.toString() : '';
-        const shiftUpper = originalText.toUpperCase();
+        const originalTextRaw = originalVal != null ? originalVal.toString() : '';
+        const isOriginalEmpty = isEffectivelyEmpty(originalTextRaw);
+        const cleanedOriginal = isOriginalEmpty ? '' : originalTextRaw.replace(/\u200b/g, '').trim();
+        const normalizedForChecks = isOriginalEmpty ? '' : stripWrappingQuotes(cleanedOriginal);
+        const shiftUpper = normalizedForChecks.toUpperCase();
         let fillColor = null;
         let cellText = '';
         if (shiftUpper.includes('NIGHT')) {
@@ -1921,7 +1952,7 @@
           // Off/leave days (including SL)
           cellText = '';
           fillColor = colors.offDay;
-        } else if (!originalText || originalText.trim() === '') {
+        } else if (isOriginalEmpty) {
           // Truly empty cell: off day color
           cellText = '';
           fillColor = colors.offDay;
@@ -1946,7 +1977,7 @@
           newSheet[cellAddress].t = 's';
         } else {
           // If no fillColor and cell is empty, fill grey
-          if (!originalText || originalText.trim() === '') {
+          if (isOriginalEmpty) {
             newSheet[cellAddress].s.fill = {
               patternType: 'solid',
               fgColor: { rgb: colors.offDay }
@@ -2008,10 +2039,14 @@
           let originalText = '';
           let timePrefix = '';
           
-          if (originalShift && originalShift[day]) {
-            originalText = originalShift[day].toString();
-            const shiftUpper = originalText.toUpperCase();
-            
+          if (originalShift && originalShift[day] !== undefined) {
+            const rawOriginal = originalShift[day];
+            const rawText = rawOriginal != null ? rawOriginal.toString() : '';
+            const originalIsEmpty = isEffectivelyEmpty(rawText);
+            originalText = originalIsEmpty ? '' : rawText.replace(/\u200b/g, '').trim();
+            const normalizedShiftText = stripWrappingQuotes(originalText);
+            const shiftUpper = normalizedShiftText.toUpperCase();
+
             // Check if originally off/leave first
             if (/^(AL|ZERO|INDUCTION|WEISS)\b/.test(shiftUpper)) {
               assignmentText = originalText;
@@ -2038,7 +2073,7 @@
             fillColor = colors.night;
           } else if (shift.on_call) {
             // On-call shift - check if LD BLEEP or LD SECOND
-            const shiftText = originalText.toUpperCase();
+            const shiftText = normalizedShiftText.toUpperCase();
             if (shiftText.includes('LD BLEEP')) {
               assignmentText = 'LD BLEEP';
               fillColor = colors.onCall;
@@ -2047,7 +2082,7 @@
               fillColor = colors.secondOnCall;
             }
             // Preserve any additional text after on-call designation
-            const parts = originalText.split(/LD BLEEP|LD SECOND/i);
+            const parts = normalizedShiftText.split(/LD BLEEP|LD SECOND/i);
             if (parts.length > 1 && parts[1].trim()) {
               assignmentText += '\n' + parts[1].trim();
             }
@@ -2089,12 +2124,15 @@
         const originalShift = rotaData.find(r => r.Name === doctorName);
         if (!originalShift || !originalShift[day]) return;
         
-        const originalText = originalShift[day].toString();
-        const shiftUpper = originalText.toUpperCase();
-        
+        let originalText = originalShift[day] != null ? originalShift[day].toString() : '';
+        const originalIsEmpty = isEffectivelyEmpty(originalText);
+        originalText = originalIsEmpty ? '' : originalText.replace(/\u200b/g, '').trim();
+        const normalizedShiftText = stripWrappingQuotes(originalText);
+        const shiftUpper = normalizedShiftText.toUpperCase();
+
         let assignmentText = originalText;
         let fillColor = null;
-        
+
         // Check if off/leave, including study leave (SL)
         if (/^(AL|SL|ZERO|INDUCTION|WEISS)\b/.test(shiftUpper)) {
           fillColor = colors.offDay;
@@ -2112,7 +2150,7 @@
             fillColor = colors.secondOnCall;
           }
           // Preserve any additional text after on-call designation
-          const parts = originalText.split(/LD BLEEP|LD SECOND/i);
+          const parts = normalizedShiftText.split(/LD BLEEP|LD SECOND/i);
           if (parts.length > 1 && parts[1].trim()) {
             assignmentText += '\n' + parts[1].trim();
           }


### PR DESCRIPTION
## Summary
- add helper utilities that recognise formula blanks and quoted text so export logic can treat them as empty
- apply the new helper when shading rota cells, ensuring empty strings are greyed while column C keeps firm colours
- normalise weekend and assignment styling to rely on the helper, preserving on-call/off-day colouring for quoted values

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df01d30c8c832893ab77407d402926